### PR TITLE
Added missing equals sign

### DIFF
--- a/R/scanoneM.R
+++ b/R/scanoneM.R
@@ -77,7 +77,7 @@ scanoneM <- function(cross, Y, tol=1e-7, n.perm=0, method=c("hk","f", "sl", "ml"
         if(is.vector(Y)) { p = 1} else {p = ncol(Y)}
     }
 
-    if( method = "hk" && dim(cross$geno[[i]]$prob) > 2 )
+    if( method == "hk" && dim(cross$geno[[i]]$prob) > 2 )
         stop("hk is not recommanded.")
     
     if(n.perm == 0) {


### PR DESCRIPTION
When installing funqtl an error occurs.

```r
library(devtools)
install_github("ikwak2/funqtl")
```

```
* installing *source* package ‘funqtl’ ...
** R
Error in parse(outFile) :
  /tmp/RtmpQiFme0/devtools5c8e501ad045/ikwak2-funqtl-f5f9a49/R/scanoneM.R:80:16: unexpected '='
79:
80:     if( method =
                   ^
ERROR: unable to collate and parse R files for package ‘funqtl’
* removing ‘/usr/lib64/R/library/funqtl’
Installation failed: Command failed (1)
```

On line 80 there was a missing equals sign in the equality operator.  This pull request adds the second equals sign.